### PR TITLE
Add .NET 6 Web API with layered cache

### DIFF
--- a/LayeredCacheApi/Cache/CacheSettings.cs
+++ b/LayeredCacheApi/Cache/CacheSettings.cs
@@ -1,0 +1,6 @@
+namespace LayeredCacheApi.Cache;
+
+public class CacheSettings
+{
+    public List<string> StaticKeyPrefixes { get; set; } = new();
+}

--- a/LayeredCacheApi/Cache/IDistributedCacheRepository.cs
+++ b/LayeredCacheApi/Cache/IDistributedCacheRepository.cs
@@ -1,0 +1,7 @@
+namespace LayeredCacheApi.Cache;
+
+public interface IDistributedCacheRepository
+{
+    Task<T?> GetAsync<T>(string key);
+    Task SetAsync<T>(string key, T value, TimeSpan? expiry = null);
+}

--- a/LayeredCacheApi/Cache/RedisCacheRepository.cs
+++ b/LayeredCacheApi/Cache/RedisCacheRepository.cs
@@ -1,0 +1,22 @@
+using EasyCaching.Core;
+
+namespace LayeredCacheApi.Cache;
+
+public class RedisCacheRepository : IDistributedCacheRepository
+{
+    private readonly IEasyCachingProvider _provider;
+
+    public RedisCacheRepository(IEasyCachingProviderFactory factory)
+    {
+        _provider = factory.GetCachingProvider("redis");
+    }
+
+    public async Task<T?> GetAsync<T>(string key)
+    {
+        var result = await _provider.GetAsync<T>(key);
+        return result.HasValue ? result.Value : default;
+    }
+
+    public Task SetAsync<T>(string key, T value, TimeSpan? expiry = null)
+        => _provider.SetAsync(key, value, expiry);
+}

--- a/LayeredCacheApi/Cache/RequestCache.cs
+++ b/LayeredCacheApi/Cache/RequestCache.cs
@@ -1,0 +1,20 @@
+namespace LayeredCacheApi.Cache;
+
+public class RequestCache
+{
+    private readonly Dictionary<string, object> _data = new();
+
+    public bool TryGet<T>(string key, out T value)
+    {
+        if (_data.TryGetValue(key, out var obj) && obj is T t)
+        {
+            value = t;
+            return true;
+        }
+        value = default!;
+        return false;
+    }
+
+    public void Set<T>(string key, T value)
+        => _data[key] = value!;
+}

--- a/LayeredCacheApi/Cache/TieredCacheRepository.cs
+++ b/LayeredCacheApi/Cache/TieredCacheRepository.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace LayeredCacheApi.Cache;
+
+public class TieredCacheRepository : IDistributedCacheRepository
+{
+    private readonly IDistributedCacheRepository _redis;
+    private readonly RequestCache _requestCache;
+    private readonly IMemoryCache _staticCache;
+    private readonly HashSet<string> _staticPrefixes;
+
+    public TieredCacheRepository(
+        IDistributedCacheRepository redis,
+        RequestCache requestCache,
+        IMemoryCache staticCache,
+        IOptions<CacheSettings> config)
+    {
+        _redis = redis;
+        _requestCache = requestCache;
+        _staticCache = staticCache;
+        _staticPrefixes = new HashSet<string>(config.Value.StaticKeyPrefixes ?? new());
+    }
+
+    private bool IsStatic(string key) => _staticPrefixes.Any(p => key.StartsWith(p, StringComparison.Ordinal));
+
+    public async Task<T?> GetAsync<T>(string key)
+    {
+        if (_requestCache.TryGet<T>(key, out var val))
+            return val;
+
+        if (IsStatic(key) && _staticCache.TryGetValue<T>(key, out var staticVal))
+        {
+            _requestCache.Set(key, staticVal);
+            return staticVal;
+        }
+
+        var remote = await _redis.GetAsync<T>(key);
+        if (remote is not null)
+        {
+            _requestCache.Set(key, remote);
+            if (IsStatic(key))
+                _staticCache.Set(key, remote, TimeSpan.FromMinutes(10));
+        }
+        return remote;
+    }
+
+    public async Task SetAsync<T>(string key, T value, TimeSpan? expiry = null)
+    {
+        _requestCache.Set(key, value);
+        if (IsStatic(key))
+            _staticCache.Set(key, value, TimeSpan.FromMinutes(10));
+        await _redis.SetAsync(key, value, expiry);
+    }
+}

--- a/LayeredCacheApi/Controllers/WeatherForecastController.cs
+++ b/LayeredCacheApi/Controllers/WeatherForecastController.cs
@@ -1,0 +1,41 @@
+using LayeredCacheApi.Cache;
+using LayeredCacheApi.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LayeredCacheApi.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class WeatherForecastController : ControllerBase
+{
+    private readonly IDistributedCacheRepository _cache;
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    public WeatherForecastController(IDistributedCacheRepository cache)
+    {
+        _cache = cache;
+    }
+
+    [HttpGet("{id}")]
+    public async Task<WeatherForecast?> Get(int id)
+    {
+        var key = $"weather:{id}";
+        var cached = await _cache.GetAsync<WeatherForecast>(key);
+        if (cached != null)
+            return cached;
+
+        var rng = new Random(id);
+        var forecast = new WeatherForecast
+        {
+            Date = DateTime.Now.AddDays(id),
+            TemperatureC = rng.Next(-20, 55),
+            Summary = Summaries[rng.Next(Summaries.Length)]
+        };
+
+        await _cache.SetAsync(key, forecast, TimeSpan.FromMinutes(1));
+        return forecast;
+    }
+}

--- a/LayeredCacheApi/LayeredCacheApi.csproj
+++ b/LayeredCacheApi/LayeredCacheApi.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
+    <PackageReference Include="EasyCaching.Core" Version="1.8.0" />
+    <PackageReference Include="EasyCaching.Redis" Version="1.8.0" />
+  </ItemGroup>
+</Project>

--- a/LayeredCacheApi/Models/WeatherForecast.cs
+++ b/LayeredCacheApi/Models/WeatherForecast.cs
@@ -1,0 +1,9 @@
+namespace LayeredCacheApi.Models;
+
+public class WeatherForecast
+{
+    public DateTime Date { get; set; }
+    public int TemperatureC { get; set; }
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    public string? Summary { get; set; }
+}

--- a/LayeredCacheApi/Program.cs
+++ b/LayeredCacheApi/Program.cs
@@ -1,0 +1,38 @@
+using LayeredCacheApi.Cache;
+using Microsoft.Extensions.Options;
+using EasyCaching.Core;
+using EasyCaching.Core.Configurations;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.Configure<CacheSettings>(builder.Configuration.GetSection("CacheSettings"));
+
+builder.Services.AddMemoryCache();
+builder.Services.AddScoped<RequestCache>();
+
+builder.Services.AddEasyCaching(options =>
+{
+    options.UseRedis(redisOpts =>
+    {
+        redisOpts.DBConfig.Endpoints.Add(new ServerEndPoint("localhost", 6379));
+        redisOpts.DBConfig.AllowAdmin = true;
+    }, "redis");
+});
+
+builder.Services.AddScoped<RedisCacheRepository>();
+
+builder.Services.AddScoped<IDistributedCacheRepository>(sp =>
+    new TieredCacheRepository(
+        sp.GetRequiredService<RedisCacheRepository>(),
+        sp.GetRequiredService<RequestCache>(),
+        sp.GetRequiredService<IMemoryCache>(),
+        sp.GetRequiredService<IOptions<CacheSettings>>()
+    ));
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();

--- a/LayeredCacheApi/README.md
+++ b/LayeredCacheApi/README.md
@@ -1,0 +1,22 @@
+# LayeredCacheApi
+
+This sample ASP.NET Core Web API demonstrates a layered caching approach using
+a per-request cache, a process-wide in-memory cache for static keys, and Redis
+via the **EasyCaching** library as the backing store.
+
+## Running
+
+The API targets .NET 6 and uses EasyCaching.Redis. Ensure Redis is running
+locally (adjust the connection string in `Program.cs` if needed) and that the
+NET 6 SDK is installed.
+
+```
+dotnet restore
+ dotnet run --project LayeredCacheApi.csproj
+```
+
+The weather forecast endpoint illustrates usage:
+`GET /WeatherForecast/1`
+
+Static key prefixes for the longer-lived cache tier can be configured in
+`appsettings.json` under `CacheSettings:StaticKeyPrefixes`.

--- a/LayeredCacheApi/appsettings.json
+++ b/LayeredCacheApi/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "CacheSettings": {
+    "StaticKeyPrefixes": [ "weather:" ]
+  }
+}


### PR DESCRIPTION
## Summary
- create new `LayeredCacheApi` sample web API
- implement request scoped cache and optional 10 minute static cache layer
- provide `TieredCacheRepository` decorator for Redis
- add example weather forecast controller
- switch Redis access to EasyCaching

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68511a5260fc832cb6392d44827248ae